### PR TITLE
Fixed startup /pc /cd working dir detection.

### DIFF
--- a/src/sys/sys_main.c
+++ b/src/sys/sys_main.c
@@ -473,9 +473,9 @@ run_game_loop:
 }
 
 int main(int argc, char **argv) {
-    FILE* fntest = fopen("/pc/sf_data/ast_logo.bin", "rb");
+    FILE* fntest = fopen("/pc/sf_data/logo.bin", "rb");
     if (NULL == fntest) {
-        fntest = fopen("/cd/sf_data/ast_logo.bin", "rb");
+        fntest = fopen("/cd/sf_data/logo.bin", "rb");
         if (NULL == fntest) {
             printf("Cant load from /pc or /cd");
             printf("\n");


### PR DESCRIPTION
1) sys_main.c
    - changed the asset used to initially detect whether we're loading from /pc or /cd from "ast_logo.bin" to "logo.bin."