### PR TITLE
Improved maple/controller/rumble performance

### DIFF
--- a/src/sys/sys_main.c
+++ b/src/sys/sys_main.c
@@ -460,7 +460,6 @@ run_game_loop:
         gSysFrameCount++;
         Graphics_InitializeTask(gSysFrameCount);
         Controller_UpdateInput();
-        Controller_Rumble();
         gSPSegment(gUnkDisp1++, 0, 0);
         gSPDisplayList(gMasterDisp++, gGfxPool->unkDL1);
         Game_Update();
@@ -473,6 +472,7 @@ run_game_loop:
 
         Audio_Update();
         gfx_end_frame();
+        Controller_Rumble();
         thd_pass();
     }
 }


### PR DESCRIPTION
- Changes:
    - Cache controller/rumble maple devices instead of rescanning every frame
    - Use maple attach/detach callbacks to rescan for controllers/rumbles only when there's actual plug/unplug activity
    - During controller/rumble scan, loop through actual device list and assign to port KOS tells us, instead of looping 4 times and assuming port assignments
    - Don't send `0` effect value to purupuru_rumble_raw (which pisses off official purupuru pack)
    - Use purupuru effects with durations instead of continuous on/off/on/off (drastically reduces maple activity)
    - Removed worker thread for rumble
    - Moved Controller_Rumble() to end of game loop

- Results:
    - Sega Jump Pack, Performance TremorPak, and Nyko DC Hyper Pak tested successfully
    - No longer get no input/"No controller" issue on title screen with jump pack inserted
    - No longer get severe loss in maple input responsiveness during play
    - Tested hotplugging controllers and rumblers, trading packs, moving around ports/slots/etc. in versus mode, with correct port/player assignments and rumbling behavior