### PR TITLE
Add support for direct loading from FAT32-formatted SD cards and IDE drives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,12 @@ LOWRES ?= 0
 ### Enable 32KHz sample rate
 USE_32KHZ ?= 0
 
+### Enable loading assets from FAT32-formatted IDE drive
+IDE_SUPPORT ?= 0
+
+### Enable loading assets from FAT32-formatted SD card
+SDCARD_SUPPORT ?= 0
+
 ### Enable testing mode
 # Turns on no damage, extra everything, and level select
 TESTING_MODE ?= 0
@@ -116,6 +122,14 @@ endif
 
 ifeq ($(USE_32KHZ),1)
   CFLAGS += -DUSE_32KHZ
+endif
+
+ifeq ($(IDE_SUPPORT),1)
+  CFLAGS += -DIDE_SUPPORT
+endif
+
+ifeq ($(SDCARD_SUPPORT),1)
+  CFLAGS += -DSDCARD_SUPPORT
 endif
 
 ifeq ($(TESTING_MODE),1)
@@ -559,6 +573,11 @@ ASSET_SYMBOLS := $(foreach elf,$(ASSET_ELFS),-Wl,--just-symbols=build/src/assets
 
 # Libraries
 LIBS := -lc -lm -lkallisti -lGL
+
+# We need libkosfat for IDE/SD card support
+ifneq (,$(filter 1,$(IDE_SUPPORT) $(SDCARD_SUPPORT)))
+  LIBS += -lkosfat
+endif
 
 default: $(ELF)
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Creating DreamShell ISO files requires `mkisofs` to be installed. This is usuall
 make dsiso
 ```
 
-### Plain files for dcload-serial or dcload-ip
+### Plain files for dcload-serial/dcload-ip or for direct loading from IDE/SD
 ```bash
 make files-zip
 ```

--- a/src/sys/sys_main.c
+++ b/src/sys/sys_main.c
@@ -10,6 +10,14 @@
 #include "gfx/gfx_dc.h"
 #include <stdlib.h>
 
+#if defined(IDE_SUPPORT) || defined(SDCARD_SUPPORT)
+#include <dc/g1ata.h>
+#include <dc/sd.h>
+#include <fat/fs_fat.h>
+
+static kos_blockdev_t dev;
+#endif
+
 #if USE_32KHZ
 #define SAMPLES_HIGH 560
 #define SAMPLES_LOW 528
@@ -364,26 +372,114 @@ void Main_ThreadEntry(void* arg0) {
     }
 }
 
-int main(int argc, char** argv) {
-    FILE* fntest = fopen("/pc/sf_data/logo.bin", "rb");
-    if (NULL == fntest) {
-        fntest = fopen("/cd/sf_data/logo.bin", "rb");
-        if (NULL == fntest) {
-            printf("Cant load from /pc or /cd");
-            printf("\n");
-            exit(-1);
-        } else {
-            printf("             using /cd for assets\n");
-            fnpre = "/cd";
-        }
-    } else {
-        printf("             using /pc for assets\n");
-        fnpre = "/pc";
-    }
+#if defined(SDCARD_SUPPORT)
+void sdcard_init(void) {
+    uint8_t partition_type;
 
+    if (sd_init())
+        return;
+
+    if (sd_blockdev_for_partition(0, &dev, &partition_type))
+        return;
+
+    if (fs_fat_mount("/sd", &dev, FS_FAT_MOUNT_READWRITE))
+        return;
+
+    printf("mounted sd card at /sd\n");
+}
+#endif
+
+#if defined(IDE_SUPPORT)
+void ide_init(void) {
+    uint8_t partition_type;
+
+    if (g1_ata_init())
+        return;
+
+    if (g1_ata_blockdev_for_partition(0, 1, &dev, &partition_type))
+        return;
+
+    if (fs_fat_mount("/ide", &dev, FS_FAT_MOUNT_READWRITE))
+        return;
+
+    printf("mounted ide partition at /ide\n");
+}
+#endif
+
+int main(int argc, char **argv) {
+    printf("Searching for assets...\n");
+
+    FILE* fntest;
+
+    printf("/pc: ");
+    fntest = fopen("/pc/sf_data/logo.bin", "rb");
+    if (fntest) {
+        printf("found. Using /pc for assets.\n");
+        fnpre = "/pc";
+        goto assetsfound;
+    }
+    printf("not found.\n");
+
+    printf("/cd: ");
+    fntest = fopen("/cd/sf_data/logo.bin", "rb");
+    if (fntest) {
+        printf("found. Using /cd for assets.\n");
+        fnpre = "/cd";
+        goto assetsfound;
+    }
+    printf("not found.\n");
+
+#if defined(IDE_SUPPORT) || defined(SDCARD_SUPPORT)
+    fs_fat_init();
+#endif
+
+#if defined(SDCARD_SUPPORT)
+    printf("/sd/sf64-dc: ");
+    sdcard_init();
+
+    fntest = fopen("/sd/sf64-dc/sf_data/logo.bin", "rb");
+    if (fntest) {
+        printf("found. Using /sd/sf64-dc for assets.\n");
+        fnpre = "/sd/sf64-dc";
+        goto assetsfound;
+    }
+    printf("not found.\n");
+#endif
+
+#if defined(IDE_SUPPORT)
+    printf("/ide/sf64-dc: ");
+    ide_init();
+
+    fntest = fopen("/ide/sf64-dc/sf_data/logo.bin", "rb");
+    if (fntest) {
+        printf("found. Using /ide/sf64-dc for assets.\n");
+        fnpre = "/ide/sf64-dc";
+        goto assetsfound;
+    }
+    printf("not found.\n");
+#endif
+
+    printf("Couldn't find assets, quitting...\n");
+    exit(-1);
+
+assetsfound:
     fclose(fntest);
 
     Main_ThreadEntry(NULL);
+
+#if defined(IDE_SUPPORT)
+    fs_fat_unmount("/ide");
+    g1_ata_shutdown();
+#endif
+
+#if defined(SDCARD_SUPPORT)
+    fs_fat_unmount("/sd");
+    sd_shutdown();
+#endif
+
+#if defined(IDE_SUPPORT) || defined(SDCARD_SUPPORT)
+    fs_fat_shutdown();
+#endif
 
     return 0;
 }


### PR DESCRIPTION
This PR adds support for loading Star Fox 64 assets and music from an SD card or an IDE drive.

Support is disabled by default. If `SDCARD_SUPPORT` or `IDE_SUPPORT` are enabled in the `Makefile`, then the `libkosfat` library provided with KallistiOS will be linked in, and `/sd/sf64-dc` and `/ide/sf64-dc` will be checked for assets (after checking `/pc` and `/cd` first).

This PR has been marked draft as there are some issues with support. In testing with an IDE drive, usually one can only get a few levels in at most before the game hangs, but it isn't understood why. The alternative Dreamcast FAT library, [FatFs](https://github.com/DC-SWAT/FatFs), also gives issues. 